### PR TITLE
Bump version to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.1 - 2023-12-15
+
+The repository was migrated to the `github.com/rust-bitocin` organization.
+This release is primarily done to fix the link on `crates.io`.
+
+- Update the `README.md` [#10](https://github.com/rust-bitcoin/rust-ordered/pull/10)
+
 # 0.2.0 - 2023-12-13
 
 - Add `AsRef`, `AsMut` imlps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ordered"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/tcharding/rust-ordered/"


### PR DESCRIPTION
In preparation for release add a changelog entry and bump the version.

From the changelog:

> The repository was migrated to the `github.com/rust-bitocin` organization.
> This release is primarily done to fix the link on `crates.io`.
