### PR TITLE
Remove unnecessary methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,16 +109,6 @@ impl<T> Ordered<T> {
     /// This allows: `let found = map.get(Ordered::from_ref(&a));`
     #[allow(clippy::ptr_as_ptr)]
     pub fn from_ref(value: &T) -> &Self { unsafe { &*(value as *const _ as *const Self) } }
-
-    /// Returns a reference to the inner object.
-    ///
-    /// We also implement [`core::borrow::Borrow`] so this function is never explicitly needed.
-    pub const fn as_inner(&self) -> &T { &self.0 }
-
-    /// Returns the inner object.
-    ///
-    /// We also implement [`core::ops::Deref`] so this function is never explicitly needed.
-    pub fn into_inner(self) -> T { self.0 }
 }
 
 impl<T: ArbitraryOrd> ArbitraryOrd for &T {


### PR DESCRIPTION
We implement a bunch of traits for getting at the inner field. Also, the inner field is public. The `into_inner` and `as_inner` methods are just clutter - remove them.

Don't bother doing a deprecation cycle because this change (and crate) is so trivial.