### PR TITLE
Add default generic type to `ArbitraryOrd`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,9 @@ use core::ops::{Deref, DerefMut};
 ///     }
 /// }
 /// ```
-pub trait ArbitraryOrd: Eq + PartialEq {
+pub trait ArbitraryOrd<Rhs = Self>: Eq + PartialEq<Rhs> {
     /// Implements a meaningless, arbitrary ordering.
-    fn arbitrary_cmp(&self, other: &Self) -> Ordering;
+    fn arbitrary_cmp(&self, other: &Rhs) -> Ordering;
 }
 
 /// A wrapper type that implements `PartialOrd` and `Ord`.


### PR DESCRIPTION
The `PartialOrd` trait uses a default generic type for the right hand side of the comparison. This is useful for example to compare an object to a foreign type. For the same reasons we should provide a default generic type to `ArbitraryOrd`.

Add generic type to `ArbitraryOrd` and default to `Self`. This adds functionality without effecting current users in any way.

I believe this also makes the trait object safe [C-OBJECT](https://rust-lang.github.io/api-guidelines/flexibility.html#c-object)

Done while checking off item in #16