### PR TITLE
Deprecate unneeded functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,16 @@ impl<T> Ordered<T> {
     /// This allows: `let found = map.get(Ordered::from_ref(&a));`
     #[allow(clippy::ptr_as_ptr)]
     pub fn from_ref(value: &T) -> &Self { unsafe { &*(value as *const _ as *const Self) } }
+
+    /// Returns a reference to the inner object.
+    ///
+    /// We also implement [`core::borrow::Borrow`] so this function is never explicitly needed.
+    pub const fn as_inner(&self) -> &T { &self.0 }
+
+    /// Returns the inner object.
+    ///
+    /// We also implement [`core::ops::Deref`] so this function is never explicitly needed.
+    pub fn into_inner(self) -> T { self.0 }
 }
 
 impl<T: ArbitraryOrd> ArbitraryOrd for &T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,11 +139,13 @@ impl<T> Ordered<T> {
     /// Returns a reference to the inner object.
     ///
     /// We also implement [`core::borrow::Borrow`] so this function is never explicitly needed.
+    #[deprecated(since = "0.3.0", note = "use `ops::Deref` instead")]
     pub const fn as_inner(&self) -> &T { &self.0 }
 
     /// Returns the inner object.
     ///
     /// We also implement [`core::ops::Deref`] so this function is never explicitly needed.
+    #[deprecated(since = "0.3.0", note = "use `ops::Deref` instead")]
     pub fn into_inner(self) -> T { self.0 }
 }
 


### PR DESCRIPTION
Don't be lazy; revert ba38763 and deprecate instead.