### PR TITLE
Bump the version to `0.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0 - 2024-12-30
+
+- Bump the MSRV to Rust `v1.63.0` [#17](https://github.com/rust-bitcoin/rust-ordered/pull/17)
+- Add default generic type to `ArbitraryOrd` for RHS [#27](https://github.com/rust-bitcoin/rust-ordered/pull/27)
+- Deprecate unneeded functions `as_inner` and `into_inner` [#28](https://github.com/rust-bitcoin/rust-ordered/pull/28)
+
 # 0.2.2 - 2023-12-18
 
 Fix the repository link in the manifest [#12](https://github.com/rust-bitcoin/rust-ordered/pull/12)

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ordered"
-version = "0.2.2"
+version = "0.3.0"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ordered"
-version = "0.2.2"
+version = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ordered"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-ordered/"


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version number, and update the lock files.

This will hopefully be the final release prior to `v1.0`. The only change in going to `v1.0` should be removal of the two deprecated functions.