### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.0 - 2024-12-31
+
+This release makes the `ArbitraryOrd` trait object safe.
+
+- Remove `Eq` trait bound [#31](https://github.com/rust-bitcoin/rust-ordered/pull/31)
+
 # 0.3.0 - 2024-12-30
 
 - Bump the MSRV to Rust `v1.63.0` [#17](https://github.com/rust-bitcoin/rust-ordered/pull/17)

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ordered"
-version = "0.3.0"
+version = "0.4.0"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ordered"
-version = "0.3.0"
+version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ordered"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-ordered/"


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version number, and update the lock files.