### PR TITLE
Improve the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ println!("Or the inner type: {}", adt.p.into_inner());
 
 ## Minimum Supported Rust Version (MSRV)
 
-The crate MSRV is Rust v1.56.1
+This library should compile with any combination of features on **Rust 1.63.0**.
+
+Use `Cargo-minimal.lock` to build the MSRV by copying to `Cargo.lock` and building.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,6 @@ let adt = Adt { x: 42, p: Foo::Space(50).into() };
 println!("We can explicitly deref: {}", *adt.p);
 println!("Or use deref coercion: {}", adt.p);
 println!("Or we can use borrow: {}", &adt.p);
-
-// And if all that is too complicated just use the inherent methods:
-
-println!("Explicitly get a reference: {}", adt.p.as_inner());
-println!("Or the inner type: {}", adt.p.into_inner());
 ```
 
 ## Minimum Supported Rust Version (MSRV)


### PR DESCRIPTION
Fix MSRV docs and remove mention of deprecated methods. PR is docs only, I'm going to smash merge.

smash merge: new term I just invented for hitting merge before CI starts while the button is green still. Extremely bad practice, you should never do that.

Close: #33