### PR TITLE
Bump version to `1.0.0-alpha.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.0-alpha.0 - 2025-30-01
+
+Alpha 1.0 release - LFG!
+
+- No code changes since `0.4.0`, improvement to the README only [#33](https://github.com/rust-bitcoin/rust-ordered/issues/33).
+
 # 0.4.0 - 2024-12-31
 
 This release makes the `ArbitraryOrd` trait object safe.

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ordered"
-version = "0.4.0"
+version = "1.0.0-alpha.0"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ordered"
-version = "0.4.0"
+version = "1.0.0-alpha.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ordered"
-version = "0.4.0"
+version = "1.0.0-alpha.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-ordered/"


### PR DESCRIPTION
In preparation for release bump the version number, add a changelog entry, and update the lock files.

This is the alpha release. Explicitly includes deprecated code that will be deleted in the `1.0` release.

This crate is the first of the so-called 'leaf crates' in `rust-bitcoin`. Defined as crates we control at the bottom of the dependency tree of the `bitcoin` crate. I know its supposed to be dependency _graph_ but then there would be no 'bottom'. There must be a real term for this?

Close: #34